### PR TITLE
Add monthly and total attendance totals to report

### DIFF
--- a/data_manager.py
+++ b/data_manager.py
@@ -255,6 +255,13 @@ class DataManager:
             # Ensure date columns are sorted correctly
             df = df[recorded_dates_sorted]
 
+            # Calculate monthly and total attendance for each child
+            months = [pd.to_datetime(d).strftime('%Y-%m') for d in recorded_dates_sorted]
+            unique_months = list(dict.fromkeys(months))
+            monthly_sums = df.groupby(months, axis=1).sum()
+            monthly_sums = monthly_sums[unique_months]
+            total_sum = df.sum(axis=1)
+            df = pd.concat([df, monthly_sums, total_sum.rename('Итого')], axis=1)
 
             report_filename = f"attendance_report_{end_date.strftime('%Y%m%d')}_last_{days}d.xlsx"
             report_filepath = os.path.join(config.REPORTS_DIR, report_filename)


### PR DESCRIPTION
## Summary
- calculate monthly attendance totals per child in Excel report
- add overall attendance totals per child

## Testing
- `pytest`
- `python -m py_compile data_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab27c399c8832d9d69583727696f62